### PR TITLE
Issue passing arguments

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ RUN chmod +x /usr/local/bin/rotor.sh
 EXPOSE 50000
 
 # Use baseimage-docker's init system.
-CMD ["/sbin/my_init", "--", "/usr/local/bin/rotor.sh"]
+ENTRYPOINT ["/sbin/my_init", "--", "/usr/local/bin/rotor.sh"]

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ depends on your service discovery registry. To see the flags available for your
 SD, run:
 
 ```console
-$ docker run --entrypoint rotor turbinelabs/rotor:0.17.0 <platform> --help
+$ docker run -e "ROTOR_CMD=help" turbinelabs/rotor:0.17.0 <platform>
 ```
 
 where `<platform>` is one of: aws, ecs, consul, file, kubernetes, or marathon.
@@ -314,13 +314,13 @@ all your services.
 ## Configuration
 
 Global flags for Rotor can be listed with
-`docker run --entrypoint rotor turbinelabs/rotor:0.17.0 --help`. Global flags can be be
+`docker run -e "ROTOR_CMD=help" turbinelabs/rotor:0.17.0`. Global flags can be be
 passed via upper-case, underscore-delimited environment variables prefixed
 with `ROTOR_`, with all non-alpha characters converted to underscores. For
 example, `--some-flag` becomes `ROTOR_SOME_FLAG`.
 
 Per-platform flags can be listed with
-`docker run --entrypoint rotor turbinelabs/rotor:0.17.0 <platform> --help`. Per-platform
+`docker run -e "ROTOR_CMD=help" turbinelabs/rotor:0.17.0 <platform>`. Per-platform
 flags can be similarly passed as environment variables, prefixed with
 `ROTOR_<PLATFORM>`. For example `--some-flag` for the kubernetes platform
 becomes `ROTOR_KUBERNETES_SOME_FLAG`.

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ all your services.
 ## Configuration
 
 Global flags for Rotor can be listed with
-`docker run --entrypoint rotor turbinelabs/rotor:0.17.0 <platform> --help`. Global flags can be be
+`docker run --entrypoint rotor turbinelabs/rotor:0.17.0 --help`. Global flags can be be
 passed via upper-case, underscore-delimited environment variables prefixed
 with `ROTOR_`, with all non-alpha characters converted to underscores. For
 example, `--some-flag` becomes `ROTOR_SOME_FLAG`.

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ depends on your service discovery registry. To see the flags available for your
 SD, run:
 
 ```console
-$ docker run turbinelabs/rotor:0.17.0 rotor <platform> --help
+$ docker run --entrypoint rotor turbinelabs/rotor:0.17.0 <platform> --help
 ```
 
 where `<platform>` is one of: aws, ecs, consul, file, kubernetes, or marathon.
@@ -314,13 +314,13 @@ all your services.
 ## Configuration
 
 Global flags for Rotor can be listed with
-`docker run turbinelabs/rotor:0.17.0 rotor --help`. Global flags can be be
+`docker run --entrypoint rotor turbinelabs/rotor:0.17.0 <platform> --help`. Global flags can be be
 passed via upper-case, underscore-delimited environment variables prefixed
 with `ROTOR_`, with all non-alpha characters converted to underscores. For
 example, `--some-flag` becomes `ROTOR_SOME_FLAG`.
 
 Per-platform flags can be listed with
-`docker run turbinelabs/rotor:0.17.0 rotor <platform> --help`. Per-platform
+`docker run --entrypoint rotor turbinelabs/rotor:0.17.0 <platform> --help`. Per-platform
 flags can be similarly passed as environment variables, prefixed with
 `ROTOR_<PLATFORM>`. For example `--some-flag` for the kubernetes platform
 becomes `ROTOR_KUBERNETES_SOME_FLAG`.

--- a/rotor.sh
+++ b/rotor.sh
@@ -25,4 +25,4 @@ if [[ -z "${ROTOR_CMD}" ]]; then
   exit 1
 fi
 
-/usr/local/bin/rotor ${ROTOR_CMD}
+/usr/local/bin/rotor ${ROTOR_CMD} "$@"


### PR DESCRIPTION
There are two issues I see with passing arguments:

1. In the Dockerfile, since CMD is specified, passing arguments to any rotor command is not possible. This works for platforms like ec2, ecs, etc since no arguments need to be passed but for **file** we need to pass the path of the file in the container as an argument.

Hence, the following command given in the README does not really work.

```
$ docker run -d \
-e 'ROTOR_CMD=file \
-p 50000:50000 \
turbinelabs/rotor:0.17.0 /path/to/file/in/container
```

To fix this, I have changed CMD to ENTRYPOINT.

2. Even if we pass arguments to the command, rotor.sh does not propagate the same to the rotor binary. I am passing those arguments to the rotor binary so that they are available to the rotor commands.

Because of the ENTRYPOINT change, running commands within the container would not work as specified in the README. Hence ```docker run turbinelabs/rotor:0.17.0 rotor <platform> --help``` needs to be changed to ```docker run --entrypoint rotor turbinelabs/rotor:0.17.0 <platform> --help```