### PR TITLE
Remove requirement of aws creds passing

### DIFF
--- a/plugins/aws/aws.go
+++ b/plugins/aws/aws.go
@@ -66,7 +66,12 @@ Tags without the namespaced cluster/port prefix will be added to all Instances
 in all Clusters to which the EC2 Instance belongs.
 
 By default, all EC2 Instances in the VPC are examined, but additional filters
-can be specified (see -filters).`
+can be specified (see -filters).
+
+Additionally, by default if AWS credentials are not passed via cli then the 
+AWS's Go SDK will fall back to its default credential chain. This first pulls
+from the environment then falls back to the task role and finally the instance
+profile role.`
 )
 
 func AWSCmd(updaterFlags rotor.UpdaterFromFlags) *command.Cmd {


### PR DESCRIPTION
AWS has a very robust default credential chain. It will first look at
ENV, then shared config files, then rely on the metadataservice that is
on every EC2 instance (more for ECS). This keeps backwards
compatability but also adds the ability to rely on this chain. This
means that `rotor` can use instance profile roles and task roles,
removing the need to pass around sensitive credentials