### PR TITLE
 add support for custom `url` tag from Consul

### DIFF
--- a/xds/adapter/rds.go
+++ b/xds/adapter/rds.go
@@ -226,7 +226,7 @@ func mkEnvoyVirtualHost(
 		corsPolicy = mkEnvoyCorsPolicy(cleanDomainConfig.Domain.CorsConfig)
 	}
 
-	domains := []string{cleanDomainConfig.Domain.Name}
+	domains := []string{cleanDomainConfig.Domain.Name, cleanDomainConfig.Domain.Addr()}
 	for _, alias := range cleanDomainConfig.Domain.Aliases {
 		domains = append(domains, string(alias))
 	}


### PR DESCRIPTION
This PR opens up a way to have customisable public facing URLs for `envoy` to listen on.