### PR TITLE
Use multi stage build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,43 +1,29 @@
-FROM phusion/baseimage:0.10.0
+FROM golang:stretch as builder
 
-# upgrade/install deps
-RUN apt-get update
-RUN DEBIAN_FRONTEND="noninteractive" apt-get upgrade -y
-RUN DEBIAN_FRONTEND="noninteractive" apt-get install -y git
-
-# install go
-RUN curl -s -L -O https://storage.googleapis.com/golang/go1.10.1.linux-amd64.tar.gz
-RUN tar -C /usr/local -xzf go1.10.1.linux-amd64.tar.gz
 ENV GOPATH /go
 ENV PATH "$PATH:/usr/local/go/bin:$GOPATH/bin"
 
 # Add src
-ADD . $GOPATH/src/github.com/turbinelabs/rotor
+COPY . $GOPATH/src/github.com/turbinelabs/rotor
 
 # Get go deps
 RUN go get github.com/turbinelabs/rotor/...
 
 # Install binaries
-RUN go install github.com/turbinelabs/rotor/...
-RUN mv $GOPATH/bin/rotor* /usr/local/bin
+RUN CGO_ENABLED=0 GOOS=linux go install github.com/turbinelabs/rotor/...
 
-# cleanup go
-RUN rm -rf /usr/local/go
-RUN rm -rf $GOPATH
+# Production image
+FROM alpine:latest
 
-# cleanup git
-RUN DEBIAN_FRONTEND="noninteractive" apt-get remove -y git
-RUN DEBIAN_FRONTEND="noninteractive" apt-get autoremove -y
+# Upgrade and apk cleanup
+RUN apk -U upgrade && rm /var/cache/apk/*
 
-# Clean up APT when done.
-RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
-
-# Add support files
-ADD rotor.sh /usr/local/bin/rotor.sh
+# Copy binaries and scripts
+COPY --from=builder /go/bin/rotor* /usr/local/bin/
+COPY rotor.sh /usr/local/bin/rotor.sh
 RUN chmod +x /usr/local/bin/rotor.sh
 
 # best guess
 EXPOSE 50000
 
-# Use baseimage-docker's init system.
-CMD ["/sbin/my_init", "--", "/usr/local/bin/rotor.sh"]
+ENTRYPOINT ["/usr/local/bin/rotor.sh"]

--- a/rotor.sh
+++ b/rotor.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/env sh
 
 # Copyright 2018 Turbine Labs, Inc.
 #


### PR DESCRIPTION
This PR reduces the size of the Docker production image by a factor of x3:
```
spoud/rotor         latest           828954300924        10 minutes ago      88.9MB
turbinelabs/rotor   0.18.2           433e4b0e0153        4 weeks ago         294MB
```